### PR TITLE
Update NamecheapResponse.js

### DIFF
--- a/lib/NamecheapResponse.js
+++ b/lib/NamecheapResponse.js
@@ -103,7 +103,7 @@ NamecheapResponse.prototype._onXMLParse = function(err,json) {
 		callback(new Error('API did not send back the command response'));
 		return;
 	}
-	if ( apiRes.RequestedCommand[0] !== apiRes.CommandResponse[0].$.Type ) {
+	if ( apiRes.RequestedCommand[0].toLowerCase() !== apiRes.CommandResponse[0].$.Type.toLowerCase() ) {
 		callback(new Error('API request and response command type mismatch'));
 		return;
 	}


### PR DESCRIPTION
string comparison failing on namecheap.domains.dns.setCustom .. 

[Error: API request and response command type mismatch]

apiRes.RequestedCommand[0] == namecheap.domains.dns.setcustom
apiRes.CommandResponse[0].$.Type == namecheap.domains.dns.setCustom

JSON.stringify(apiRes) 
"$":{"Status":"OK","xmlns":"http://api.namecheap.com/xml.response"},"Errors":[""],"Warnings":[""],"RequestedCommand":["namecheap.domains.dns.setcustom"],"CommandResponse":[{"$":{"Type":"namecheap.domains.dns.setCustom"},"DomainDNSSetCustomResult":[{"$":{"Domain":"x.com","Updated":"true"}}]}],"Server":["PHX01APIEXT02"],"GMTTimeDifference":["--4:00"],"ExecutionTime":["2.728"]}
